### PR TITLE
Typo in 14-vim9script.md

### DIFF
--- a/lectures/slides/14-vim9script.md
+++ b/lectures/slides/14-vim9script.md
@@ -145,7 +145,7 @@ vim9script
 
 def g:Global(one: number, two: number): bool
   var sum = Local(one, two)
-  sum -= 1
+  sum += 1
 
   return sum > 0
 enddef


### PR DESCRIPTION
The other example was with `+=` so I decided to make it the same.